### PR TITLE
KotlinParseException on string concatenation in fix plugin

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringConcatenationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringConcatenationRule.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtOperationExpression
 import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 /**
@@ -153,7 +154,8 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
             // =========== "a " + "b" -> "a b"
             val rvalueTextNew = rvalueText?.trim('"')
             return "$lvalueText$rvalueTextNew"
-        } else if (binaryExpressionPsi.isRvalueCallExpression() || binaryExpressionPsi.isRvalueDotQualifiedExpression() || binaryExpressionPsi.isRvalueOperation()) {
+        } else if (binaryExpressionPsi.isRvalueCallExpression() || binaryExpressionPsi.isRvalueDotQualifiedExpression() ||
+                binaryExpressionPsi.isRvalueOperation() || binaryExpressionPsi.isRvalueSafeQualifiedExpression()) {
             // ===========  "a " + foo() -> "a ${foo()}}"
             return "$lvalueText\${$rvalueText}"
         } else if (binaryExpressionPsi.isRvalueReferenceExpression()) {
@@ -216,4 +218,7 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun KtBinaryExpression.isLvalueConstantExpression() =
             this.left is KtConstantExpression
+
+    private fun KtBinaryExpression.isRvalueSafeQualifiedExpression() =
+            this.right is KtSafeQualifiedExpression
 }

--- a/diktat-rules/src/test/resources/test/paragraph3/string_concatenation/StringConcatenationExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/string_concatenation/StringConcatenationExpected.kt
@@ -32,3 +32,4 @@ val myTest21 = "${x} string"
 val myTest22 = "string${foo()}"
 val myTest23 = x.toString() + foo()
 val myTest24 = foo() + "string"
+val myTest25 = "String ${valueStr?.value}"

--- a/diktat-rules/src/test/resources/test/paragraph3/string_concatenation/StringConcatenationTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/string_concatenation/StringConcatenationTest.kt
@@ -32,3 +32,4 @@ val myTest21 = x.toString() + " string"
 val myTest22 = "string" + foo()
 val myTest23 = x.toString() + foo()
 val myTest24 = foo() + "string"
+val myTest25 = "String " + valueStr?.value


### PR DESCRIPTION
### What's done:
* fixed null-safety in rule
This pull request closes #1181 