### PR TITLE
Fix: CLASS_SHOULD_NOT_BE_ABSTRACT breaks code when abstract class implements an interface

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/AbstractClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/AbstractClassesRule.kt
@@ -16,6 +16,7 @@ import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.OPEN_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.PROPERTY
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_TYPE_CALL_ENTRY
+import com.pinterest.ktlint.core.ast.ElementType.SUPER_TYPE_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_TYPE_LIST
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -35,6 +36,7 @@ class AbstractClassesRule(configRules: List<RulesConfig>) : DiktatRule(
 
             // If an abstract class extends another class, than that base class can be abstract too.
             // Then this class must have `abstract` modifier even if it doesn't have any abstract members.
+            // Class also must have `abstract` modifier if it implements interface
             if (node.hasAbstractModifier() && node.isNotSubclass()) {
                 handleAbstractClass(classBody, node)
             }
@@ -45,7 +47,7 @@ class AbstractClassesRule(configRules: List<RulesConfig>) : DiktatRule(
             getFirstChildWithType(MODIFIER_LIST)?.hasChildOfType(ABSTRACT_KEYWORD) ?: false
 
     private fun ASTNode.isNotSubclass(): Boolean = findChildByType(SUPER_TYPE_LIST)?.children()?.filter {
-        it.elementType == SUPER_TYPE_CALL_ENTRY
+        it.elementType == SUPER_TYPE_CALL_ENTRY || it.elementType == SUPER_TYPE_ENTRY
     }?.none() ?: true
 
     @Suppress("UnsafeCallOnNullableType")

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/AbstractClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/AbstractClassesRule.kt
@@ -36,7 +36,7 @@ class AbstractClassesRule(configRules: List<RulesConfig>) : DiktatRule(
 
             // If an abstract class extends another class, than that base class can be abstract too.
             // Then this class must have `abstract` modifier even if it doesn't have any abstract members.
-            // Class also must have `abstract` modifier if it implements interface
+            // Class also can have `abstract` modifier if it implements interface
             if (node.hasAbstractModifier() && node.isNotSubclass()) {
                 handleAbstractClass(classBody, node)
             }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/AbstractClassesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/AbstractClassesWarnTest.kt
@@ -116,14 +116,13 @@ class AbstractClassesWarnTest : LintTestBase(::AbstractClassesRule) {
 
     @Test
     @Tag(CLASS_SHOULD_NOT_BE_ABSTRACT)
-    fun `should trigger on classes that implement interfaces`() {
+    fun `should not trigger on classes that implement interfaces`() {
         lintMethod(
             """
                 |abstract class Example: Base {
                 |    fun foo() {}
                 |}
             """.trimMargin(),
-            LintError(1, 30, ruleId, "[CLASS_SHOULD_NOT_BE_ABSTRACT] class should not be abstract, because it has no abstract functions: Example", true)
         )
     }
 }


### PR DESCRIPTION
### What's done:
* Class can have `abstract` modifier if it implements interface, don't trigger on such cases