### PR TITLE
Add `--add-opens` in gradle plugin on JVM >=16

### DIFF
--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePlugin.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePlugin.kt
@@ -69,5 +69,10 @@ class DiktatGradlePlugin : Plugin<Project> {
          * Task to run diKTat with fix
          */
         const val DIKTAT_FIX_TASK = "diktatFix"
+
+        /**
+         * Version of JVM with more strict module system, which requires `add-opens` for kotlin compiler
+         */
+        const val MIN_JVM_REQUIRES_ADD_OPENS = 16
     }
 }

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -6,6 +6,7 @@ import org.cqfn.diktat.ruleset.rules.DIKTAT_CONF_PROPERTY
 
 import generated.DIKTAT_VERSION
 import generated.KTLINT_VERSION
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
@@ -33,7 +34,7 @@ import javax.inject.Inject
  * Note: class being `open` is required for gradle to create a task.
  */
 open class DiktatJavaExecTaskBase @Inject constructor(
-    gradleVersionString: String,
+    private val gradleVersionString: String,
     diktatExtension: DiktatExtension,
     diktatConfiguration: Configuration,
     private val inputs: PatternFilterable,
@@ -133,6 +134,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
      */
     @TaskAction
     override fun exec() {
+        fixForNewJpms()
         if (shouldRun) {
             super.exec()
         } else {
@@ -212,6 +214,27 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                 firstOrNull { it.exists() } ?: first()
             }
             .absolutePath
+    }
+
+    private fun fixForNewJpms() {
+        val javaVersion = getJavaExecJvmVersion()
+        project.logger.debug("For diktat execution jvm version $javaVersion will be used")
+        if (javaVersion >= JavaVersion.VERSION_16) {
+            // https://github.com/analysis-dev/diktat/issues/1182#issuecomment-1023099713
+            project.logger.debug("Adding `--add-opens` flag for JVM version >=16 compatibility")
+            jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+        }
+    }
+
+    private fun getJavaExecJvmVersion(): JavaVersion = if (GradleVersion.version(gradleVersionString) >= GradleVersion.version("6.7") &&
+            javaLauncher.isPresent
+    ) {
+        // Java Launchers are available since 6.7, but may not always be configured
+        javaLauncher.map { it.metadata.jvmVersion }.map(JavaVersion::toVersion).get()
+    } else {
+        // `javaVersion` property is available since 5.2 and is simply derived from path to JVM executable,
+        // which may be explicitly set or be the same as current Gradle JVM.
+        javaVersion
     }
 }
 

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -2,6 +2,7 @@ package org.cqfn.diktat.plugin.gradle
 
 import org.cqfn.diktat.plugin.gradle.DiktatGradlePlugin.Companion.DIKTAT_CHECK_TASK
 import org.cqfn.diktat.plugin.gradle.DiktatGradlePlugin.Companion.DIKTAT_FIX_TASK
+import org.cqfn.diktat.plugin.gradle.DiktatGradlePlugin.Companion.MIN_JVM_REQUIRES_ADD_OPENS
 import org.cqfn.diktat.ruleset.rules.DIKTAT_CONF_PROPERTY
 
 import generated.DIKTAT_VERSION
@@ -219,9 +220,9 @@ open class DiktatJavaExecTaskBase @Inject constructor(
     private fun fixForNewJpms() {
         val javaVersion = getJavaExecJvmVersion()
         project.logger.debug("For diktat execution jvm version $javaVersion will be used")
-        if (javaVersion.majorVersion.toInt() >= 16) {
+        if (javaVersion.majorVersion.toInt() >= MIN_JVM_REQUIRES_ADD_OPENS) {
             // https://github.com/analysis-dev/diktat/issues/1182#issuecomment-1023099713
-            project.logger.debug("Adding `--add-opens` flag for JVM version >=16 compatibility")
+            project.logger.debug("Adding `--add-opens` flag for JVM version >=$MIN_JVM_REQUIRES_ADD_OPENS compatibility")
             jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
         }
     }

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -219,7 +219,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
     private fun fixForNewJpms() {
         val javaVersion = getJavaExecJvmVersion()
         project.logger.debug("For diktat execution jvm version $javaVersion will be used")
-        if (javaVersion >= JavaVersion.VERSION_16) {
+        if (javaVersion.majorVersion.toInt() >= 16) {
             // https://github.com/analysis-dev/diktat/issues/1182#issuecomment-1023099713
             project.logger.debug("Adding `--add-opens` flag for JVM version >=16 compatibility")
             jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")


### PR DESCRIPTION
### What's done:
* Add logic

It seems that we can't support this workaround in maven plugin, because it does not use `java-exec`. The `--add-opnes` flag should be added to Maven JVM itself.

This pull request closes #1203