### PR TITLE
maven-plugin: Fix scopes of maven dependencies

### DIFF
--- a/diktat-maven-plugin/pom.xml
+++ b/diktat-maven-plugin/pom.xml
@@ -29,11 +29,13 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.api.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.api.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
### What's done:
* Some dependencies for maven plugins are included in maven runtime and thus should have `provided` scope

This pull request closes #1249 