### PR TITLE
Rollback nexus-staging-maven-plugin to 1.6.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.11</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Latest release workflow has failed with the following error:
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy (injected-nexus-deploy) on project org.cqfn.diktat.diktat-gradle-plugin.gradle.plugin: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy: java.lang.IllegalAccessError: class com.sonatype.nexus.staging.client.internal.StagingWorkflowV3ServiceImpl tried to access method 'void com.google.common.base.Stopwatch.<init>()' (com.sonatype.nexus.staging.client.internal.StagingWorkflowV3ServiceImpl and com.google.common.base.Stopwatch are in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @cda6019)
```
I managed to find the following mentions of this error:
https://issues.sonatype.org/browse/NEXUS-31301
https://issues.sonatype.org/browse/OSSRH-66257, which mentions `At this time, it's best to avoid 1.6.9/1.6.10/1.6.11 releases of the plugin.`
https://issues.sonatype.org/browse/NEXUS-31214: `The stopwatch issue [NEXUS-31301](https://issues.sonatype.org/browse/NEXUS-31301) still occurs on 1.6.12`

So I guess we'll have to stick with this version for a bit... That's a shame, that they use JIRA for release management and neither does Dependabot link release notes, nor is searching through issues fast or convenient.