### PR TITLE
Replace property 'reporterType' by 'reporter' in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,14 @@ diktat {
 Also `diktat` extension has different reporters. You can specify `json`, `html`, `sarif`, `plain` (default) or your own custom reporter (it should be added as a dependency into `diktat` configuration):
 ```kotlin
 diktat {
-   reporterType = "json" // "html", "json", "plain" (default), "sarif"
+   reporter = "json" // "html", "json", "plain" (default), "sarif"
 }
 ```
 
 You can also specify an output. 
 ```kotlin
 diktat {
-    reporterType = "json"
+    reporter = "json"
     output = "someFile.json"
 }
 ```
@@ -250,7 +250,7 @@ Diktat can be run via spotless-maven-plugin since version 2.8.0
 </details>
 
 ## GitHub Native Integration
-We suggest everyone to use common ["sarif"](https://docs.oasis-open.org/sarif/sarif/v2.0/sarif-v2.0.html) format as a `reporterType` in CI/CD.
+We suggest everyone to use common ["sarif"](https://docs.oasis-open.org/sarif/sarif/v2.0/sarif-v2.0.html) format as a `reporter` in CI/CD.
 GitHub has an [integration](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning)
 with SARIF format and provides you a native reporting of diktat issues in Pull Requests.
 


### PR DESCRIPTION
## Description
Since https://github.com/analysis-dev/diktat/commit/237cb2c7e289e7857eabcedc906566c65d468bdd (embedded in releases 1.0.3 and 1.1.0), the name of the property in README.md file was not aligned with the definition of the property in DiktatExtension.kt file

## What's done
* Replace property 'reporterType' by 'reporter' in README file